### PR TITLE
support for components as self contained artifacts

### DIFF
--- a/plugin/src/main/java/org/wso2/carbon/uuf/maven/AppMojo.java
+++ b/plugin/src/main/java/org/wso2/carbon/uuf/maven/AppMojo.java
@@ -404,10 +404,10 @@ public class AppMojo extends ComponentMojo {
             // root component
             return pathOf(componentsDirectory, DIRECTORY_ROOT_COMPONENT, fileName);
         } else {
-            int lastIndex = artifactId.lastIndexOf(".");
+            int lastIndex = componentArtifactId.lastIndexOf(".");
             String componentContext;
             if (lastIndex > -1) {
-                componentContext = artifactId.substring(lastIndex + 1);
+                componentContext = componentArtifactId.substring(lastIndex + 1);
             } else {
                 componentContext = componentArtifactId;
             }

--- a/plugin/src/main/java/org/wso2/carbon/uuf/maven/ComponentMojo.java
+++ b/plugin/src/main/java/org/wso2/carbon/uuf/maven/ComponentMojo.java
@@ -25,6 +25,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.wso2.carbon.uuf.maven.exception.ParsingException;
+import org.wso2.carbon.uuf.maven.model.Bundle;
 import org.wso2.carbon.uuf.maven.model.DependencyNode;
 import org.wso2.carbon.uuf.maven.parser.ComponentManifestParser;
 import org.wso2.carbon.uuf.maven.parser.ConfigurationParser;
@@ -48,6 +49,7 @@ public class ComponentMojo extends AbstractUUFMojo {
     protected static final String CONFIGURATION_IMPORT_PACKAGE = "Import-Package";
     protected static final String FILE_CONFIG = "config.yaml";
     protected static final String FILE_COMPONENT_MANIFEST = "component.yaml";
+    public static final String FILE_BUNDLE_DEPENDENCIES = "bundle-dependencies.yaml";
 
     /**
      * Path to the temporary directory for UUF Maven plugin.
@@ -60,6 +62,12 @@ public class ComponentMojo extends AbstractUUFMojo {
      */
     @Parameter(readonly = true, required = false)
     protected Map<String, String> instructions;
+
+    /**
+     * Configured OSGi bundles.
+     */
+    @Parameter(property = "bundles", readonly = true, required = false)
+    protected List<Bundle> bundles;
 
     /**
      * {@inheritDoc}
@@ -97,6 +105,11 @@ public class ComponentMojo extends AbstractUUFMojo {
                 ConfigFileCreator.createOsgiImports(osgiImportsContent, tempDirectoryPath);
                 sourceDirectoryPaths.add(tempDirectoryPath);
             }
+        }
+        // Create component level bundle-dependencies.yaml file
+        if (bundles != null && !bundles.isEmpty()) {
+            ConfigFileCreator.createBundleDependenciesYaml(bundles, tempDirectoryPath);
+            sourceDirectoryPaths.add(tempDirectoryPath);
         }
         // Create zip file.
         sourceDirectoryPaths.add(sourceDirectoryPath);

--- a/plugin/src/main/java/org/wso2/carbon/uuf/maven/model/BundleListConfig.java
+++ b/plugin/src/main/java/org/wso2/carbon/uuf/maven/model/BundleListConfig.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.carbon.uuf.maven.model;
+
+import java.util.List;
+
+/**
+ * Bean class to represent list of OSGi bundles added as dependencies for components in uuf-maven plugin configuration.
+ *
+ * @since 1.0.0
+ */
+public class BundleListConfig {
+    private List<Bundle> bundles;
+
+    /**
+     * Sets given bundle list instance read from yaml or uuf-maven plugin configuration.
+     * @param bundles list of bundles
+     */
+    public void setBundles(List<Bundle> bundles) {
+        this.bundles = bundles;
+    }
+
+    /**
+     * Returns the bundle list held by this configuration instance.
+     * @return bundle list
+     */
+    public List<Bundle> getBundles() {
+        return bundles;
+    }
+}

--- a/plugin/src/main/java/org/wso2/carbon/uuf/maven/parser/ConfigurationParser.java
+++ b/plugin/src/main/java/org/wso2/carbon/uuf/maven/parser/ConfigurationParser.java
@@ -61,4 +61,28 @@ public class ConfigurationParser {
     static Map parseString(String config) throws Exception {
         return new Yaml().loadAs(config, Map.class);
     }
+
+    /**
+     * A generic parse method that parses the given yaml content file and de-serialize the content into given bean type.
+     *
+     * @param configFilePath path to yaml file.
+     * @param type type of the bean class to be used when de-serializing.
+     * @param <T> type of the bean class to be used when de-serializing.
+     * @return returns the populated bean instance.
+     * @throws ParsingException thrown when the given yaml file cannot be parsed properly
+     */
+    public static <T> T parse(String configFilePath, Class<T> type) throws ParsingException {
+        Path configFile = Paths.get(configFilePath);
+        if (!Files.exists(configFile)) {
+            return null;
+        }
+        try {
+            String content = new String(Files.readAllBytes(configFile), StandardCharsets.UTF_8);
+            return new Yaml().loadAs(content, type);
+        } catch (IOException e) {
+            throw new ParsingException("Cannot read the content of config file '" + configFilePath + "'.", e);
+        } catch (Exception e) {
+            throw new ParsingException("Cannot parse the content of config file '" + configFilePath + "'.", e);
+        }
+    }
 }

--- a/plugin/src/main/java/org/wso2/carbon/uuf/maven/serializer/ConfigurationSerializer.java
+++ b/plugin/src/main/java/org/wso2/carbon/uuf/maven/serializer/ConfigurationSerializer.java
@@ -19,8 +19,11 @@
 package org.wso2.carbon.uuf.maven.serializer;
 
 import org.wso2.carbon.uuf.maven.exception.SerializationException;
+import org.wso2.carbon.uuf.maven.model.BundleListConfig;
 import org.wso2.carbon.uuf.maven.model.Configuration;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Representer;
 
 /**
  * YAML serializer for {@link Configuration} model.
@@ -29,20 +32,30 @@ import org.yaml.snakeyaml.Yaml;
  */
 public class ConfigurationSerializer {
 
-    private final Yaml yaml = new Yaml();
-
     /**
-     * Serializes the specified config into a YAML.
+     * Serializes the given application configuration into a YAML.
      *
      * @param configuration config to serialize
      * @return YAML representation of the config
      * @throws SerializationException if an error occurred during serialization
      */
-    public String serialize(Configuration configuration) throws SerializationException {
+    public static String serialize(Configuration configuration) throws SerializationException {
         try {
-            return yaml.dumpAsMap(configuration.asMap());
+            return new Yaml().dumpAsMap(configuration.asMap());
         } catch (Exception e) {
             throw new SerializationException("Cannot serialize config " + configuration + ".", e);
         }
+    }
+
+    /**
+     * Serializes the given data configuration object as it is and returns the YAML representation value.
+     *
+     * @param data any data object to be serialized
+     * @return YAML representation of the given data configuration.
+     */
+    public static String serialize(Object data) {
+        Representer representer = new Representer();
+        representer.addClassTag(BundleListConfig.class, Tag.MAP);
+        return new Yaml(representer).dump(data);
     }
 }

--- a/plugin/src/main/java/org/wso2/carbon/uuf/maven/util/ConfigFileCreator.java
+++ b/plugin/src/main/java/org/wso2/carbon/uuf/maven/util/ConfigFileCreator.java
@@ -20,6 +20,12 @@ package org.wso2.carbon.uuf.maven.util;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.wso2.carbon.uuf.maven.model.Bundle;
+import org.wso2.carbon.uuf.maven.model.BundleListConfig;
+import org.wso2.carbon.uuf.maven.serializer.ConfigurationSerializer;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Representer;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,7 +35,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.wso2.carbon.uuf.maven.ComponentMojo.FILE_BUNDLE_DEPENDENCIES;
 
 /**
  * Utility class that creates various configuration files needed by the UUF project creation Mojo's.
@@ -68,6 +77,30 @@ public class ConfigFileCreator {
         } catch (IOException e) {
             throw new MojoExecutionException(
                     "Cannot create '" + FILE_OSGI_IMPORTS + "' file in '" + outputDirectoryPath + "'.", e);
+        }
+    }
+
+    /**
+     * Creates the bundle-dependencies.yaml file in the given output directory path.
+     *
+     * @param bundles the list of bundles instance used with creating the bundle-dependencies.yaml
+     * @param outputDirectoryPath output location path use with creating yaml file.
+     * @throws MojoExecutionException thrown when an error occurs while creating or writing the yaml file.
+     */
+    public static void createBundleDependenciesYaml(List<Bundle> bundles, String outputDirectoryPath)
+            throws MojoExecutionException {
+        if (bundles == null || bundles.isEmpty()) {
+           return;
+        }
+        try {
+            createDirectory(Paths.get(outputDirectoryPath));
+            BundleListConfig bundleListConfig = new BundleListConfig();
+            bundleListConfig.setBundles(bundles);
+            String content = ConfigurationSerializer.serialize(bundleListConfig);
+            writeFile(Paths.get(outputDirectoryPath, FILE_BUNDLE_DEPENDENCIES), content);
+        } catch (IOException e) {
+            throw new MojoExecutionException(
+                    "Cannot create '" + FILE_BUNDLE_DEPENDENCIES + "' file in '" + outputDirectoryPath + "'.", e);
         }
     }
 


### PR DESCRIPTION
Currently component level bundle dependencies are defined in the application and then used with creating the carbon-feature. this was a limitation with components as app developers has to know about their components bundle dependencies and define that in their app configuration. 

To solve this issue, a new file is created with components where it stores the metadata about the bundle dependencies within the component archive itself. this files is then read and fed into application level bundle dependency list so that component level bundle dependencies are also used when creating the app feature.