### PR TITLE
Adding 'uuf-app-zip' goal for UUF apps

### DIFF
--- a/plugin/src/main/java/org/wso2/carbon/uuf/maven/AbstractAppMojo.java
+++ b/plugin/src/main/java/org/wso2/carbon/uuf/maven/AbstractAppMojo.java
@@ -69,7 +69,7 @@ import static org.twdata.maven.mojoexecutor.MojoExecutor.version;
  */
 @Mojo(name = "create-app", inheritByDefault = false, requiresDependencyResolution = ResolutionScope.COMPILE,
       threadSafe = true, defaultPhase = LifecyclePhase.PACKAGE)
-public class AppMojo extends ComponentMojo {
+public class AbstractAppMojo extends ComponentMojo {
 
     private static final String FILE_APP_CONFIG = "app.yaml";
     private static final String FILE_DEPENDENCY_TREE = "dependency.tree";
@@ -144,7 +144,7 @@ public class AppMojo extends ComponentMojo {
         copyFiles(sourceDirectoryPath, pathOf(allComponentsDirectory, DIRECTORY_ROOT_COMPONENT));
         // 2.2 Create "osgi-imports" file for the "root" component.
         if ((instructions != null) &&
-            (instructions.getImportPackage() != null) && (!instructions.getImportPackage().isEmpty())) {
+                (instructions.getImportPackage() != null) && (!instructions.getImportPackage().isEmpty())) {
             ConfigFileCreator.createOsgiImports(instructions.getImportPackage(),
                                                 pathOf(allComponentsDirectory, DIRECTORY_ROOT_COMPONENT));
         }
@@ -167,7 +167,7 @@ public class AppMojo extends ComponentMojo {
         if (!ARTIFACT_TYPE_UUF_APP.equals(packaging)) {
             throw new MojoExecutionException(
                     "Packaging type of an UUF App should be '" + ARTIFACT_TYPE_UUF_APP + "'. Instead found '" +
-                    packaging + "'.");
+                            packaging + "'.");
         }
         // Validation: Artifact ID should end with '.feature'
         if (!artifactId.endsWith(APP_ARTIFACT_ID_TAIL)) {
@@ -180,7 +180,7 @@ public class AppMojo extends ComponentMojo {
             YamlFileParser.parse(componentConfigFilePath, ComponentConfig.class);
         } catch (ParsingException e) {
             throw new MojoExecutionException("Component configuration file '" + componentConfigFilePath + "' of '" +
-                                             artifactId + "' UUF App is invalid.", e);
+                                                     artifactId + "' UUF App is invalid.", e);
         }
         // Validation: Parse app configuration file to make sure it is valid.
         parseAppConfig();
@@ -235,14 +235,14 @@ public class AppMojo extends ComponentMojo {
                     componentConfig = YamlFileParser.parse(configFilePath, ComponentConfig.class);
                 } catch (ParsingException e) {
                     throw new RuntimeException("Cannot parse '" + FILE_COMPONENT_CONFIG + "' of " + node +
-                                               " which read from '" + configFilePath + "' path.", e);
+                                                       " which read from '" + configFilePath + "' path.", e);
                 }
                 try {
                     configuration.merge(componentConfig.getConfig());
                 } catch (IllegalArgumentException e) {
                     throw new RuntimeException(
                             "Cannot merge configuration Map parsed from '" + FILE_COMPONENT_CONFIG + "' of " + node +
-                            " which read from '" + configFilePath + "' path.", e);
+                                    " which read from '" + configFilePath + "' path.", e);
                 }
             });
         } catch (RuntimeException e) {
@@ -280,7 +280,8 @@ public class AppMojo extends ComponentMojo {
                     bundleListConfig = YamlFileParser.parse(bundleDependenciesFilePath, BundleListConfig.class);
                 } catch (ParsingException e) {
                     throw new RuntimeException("Cannot parse '" + FILE_BUNDLES + "' of " + node +
-                                               " which read from '" + bundleDependenciesFilePath + "' path.", e);
+                                                       " which read from '" + bundleDependenciesFilePath + "' path.",
+                                               e);
                 }
                 if (bundleListConfig == null) {
                     return;
@@ -291,7 +292,8 @@ public class AppMojo extends ComponentMojo {
                     Files.delete(Paths.get(bundleDependenciesFilePath));
                 } catch (IOException e) {
                     throw new RuntimeException("Cannot delete '" + FILE_BUNDLES + "' of " + node +
-                                               " which read from '" + bundleDependenciesFilePath + "' path.", e);
+                                                       " which read from '" + bundleDependenciesFilePath + "' path.",
+                                               e);
                 }
             });
         } catch (Exception e) {
@@ -420,7 +422,7 @@ public class AppMojo extends ComponentMojo {
             return YamlFileParser.parse(appConfigFilePath, AppConfig.class);
         } catch (ParsingException e) {
             throw new MojoExecutionException("App configuration file '" + appConfigFilePath + "' of '" +
-                                             artifactId + "' UUF App is invalid.", e);
+                                                     artifactId + "' UUF App is invalid.", e);
         }
     }
 }

--- a/plugin/src/main/java/org/wso2/carbon/uuf/maven/AbstractUUFMojo.java
+++ b/plugin/src/main/java/org/wso2/carbon/uuf/maven/AbstractUUFMojo.java
@@ -33,10 +33,6 @@ import java.nio.file.Paths;
  */
 public abstract class AbstractUUFMojo extends AbstractMojo {
 
-    protected static final String ARTIFACT_TYPE_UUF_APP = "carbon-feature";
-    protected static final String ARTIFACT_TYPE_UUF_COMPONENT = "uuf-component";
-    protected static final String ARTIFACT_TYPE_UUF_THEME = "uuf-theme";
-
     /**
      * Associated Maven project with this Mojo.
      */

--- a/plugin/src/main/java/org/wso2/carbon/uuf/maven/AppFeatureMojo.java
+++ b/plugin/src/main/java/org/wso2/carbon/uuf/maven/AppFeatureMojo.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uuf.maven;
+
+import org.apache.maven.model.Resource;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.twdata.maven.mojoexecutor.MojoExecutor;
+import org.wso2.carbon.uuf.maven.bean.mojo.Bundle;
+import org.wso2.carbon.uuf.maven.util.ConfigFileCreator;
+
+import java.util.Collections;
+
+import static org.twdata.maven.mojoexecutor.MojoExecutor.artifactId;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.configuration;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.element;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.executeMojo;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.executionEnvironment;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.goal;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.groupId;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.name;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.plugin;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.version;
+
+/**
+ * Creates a Carbon Feature for an UUF app.
+ *
+ * @since 1.0.0
+ */
+@Mojo(name = "create-app", inheritByDefault = false, requiresDependencyResolution = ResolutionScope.COMPILE,
+      threadSafe = true, defaultPhase = LifecyclePhase.PACKAGE)
+public class AppFeatureMojo extends AbstractAppMojo {
+
+    public static final String ARTIFACT_TYPE_UUF_APP = "carbon-feature";
+    private static final String APP_ARTIFACT_ID_TAIL = ".feature";
+
+    /**
+     * Path to the output directory of this Mojo
+     */
+    @Parameter(defaultValue = "${project.build.directory}/maven-shared-archive-resources/uufapps/",
+               readonly = true, required = true)
+    private String outputDirectoryPath;
+
+    /**
+     * Carbon Feature Plugin version to use.
+     */
+    @Parameter(defaultValue = "3.0.0", readonly = true, required = false)
+    private String carbonFeaturePluginVersion;
+
+    @Override
+    protected String getOutputDirectoryPath() {
+        return pathOf(outputDirectoryPath, getAppFulyQualifiedName(artifactId));
+    }
+
+    @Override
+    protected void createProjectArtifact() throws MojoExecutionException {
+        String appFullyQualifiedName = getAppFulyQualifiedName(artifactId);
+        // Create a 'resources' directory and add it to the project as a resources directory.
+        String tempResourcesDirectoryPath = pathOf(tempDirectoryPath, "resources");
+        Resource resource = new Resource();
+        resource.setDirectory(tempResourcesDirectoryPath);
+        project.addResource(resource);
+        // Create the "p2.inf" file in that 'resources' directory.
+        ConfigFileCreator.createP2Inf(appFullyQualifiedName, tempResourcesDirectoryPath);
+        // Create Carbon Feature.
+        try {
+            executeMojo(
+                    plugin(
+                            groupId("org.wso2.carbon.maven"),
+                            artifactId("carbon-feature-plugin"),
+                            version(carbonFeaturePluginVersion)
+                    ),
+                    goal("generate"),
+                    configuration(
+                            element(name("propertyFile"), ConfigFileCreator.createFeatureProperties(tempDirectoryPath)),
+                            element(name("adviceFileContents"),
+                                    element(name("advice"),
+                                            element(name("name"), "org.wso2.carbon.p2.category.type"),
+                                            element(name("value"), "server")
+                                    )
+                            ),
+                            element(name("bundles"),
+                                    (bundles == null ? Collections.<Bundle>emptyList() : bundles).stream()
+                                            .map(bundle -> element(name("bundle"),
+                                                                   element(name("symbolicName"),
+                                                                           bundle.getSymbolicName()),
+                                                                   element(name("version"), bundle.getVersion()))
+                                            ).toArray(MojoExecutor.Element[]::new))
+                    ),
+                    executionEnvironment(project, session, pluginManager)
+            );
+        } catch (MojoExecutionException e) {
+            throw new MojoExecutionException(
+                    "Cannot create Carbon Feature for UUF App '" + appFullyQualifiedName + "'.", e);
+        }
+    }
+
+    @Override
+    protected void validate() throws MojoExecutionException {
+        // Validation: Packaging type should be 'carbon-feature'
+        if (!ARTIFACT_TYPE_UUF_APP.equals(packaging)) {
+            throw new MojoExecutionException(
+                    "Packaging type of an UUF App should be '" + ARTIFACT_TYPE_UUF_APP + "'. Instead found '" +
+                            packaging + "'.");
+        }
+        // Validation: Artifact ID should end with '.feature'
+        if (!artifactId.endsWith(APP_ARTIFACT_ID_TAIL)) {
+            throw new MojoExecutionException(
+                    "Artifact ID of an UUF App should end with '.feature' as it is packaged as a Carbon Feature.");
+        }
+        super.validate();
+    }
+
+    private static String getAppFulyQualifiedName(String artifactId) {
+        // Compute the App's fully qualified name by removing ".feature" from the artifact ID.
+        return artifactId.substring(0, (artifactId.length() - APP_ARTIFACT_ID_TAIL.length()));
+    }
+}

--- a/plugin/src/main/java/org/wso2/carbon/uuf/maven/AppZipMojo.java
+++ b/plugin/src/main/java/org/wso2/carbon/uuf/maven/AppZipMojo.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uuf.maven;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.wso2.carbon.uuf.maven.util.ZipCreator;
+
+import java.io.File;
+import java.util.Collections;
+
+/**
+ * Creates a zip archive for an UUF app.
+ *
+ * @since 1.0.0
+ */
+@Mojo(name = "create-app-zip", inheritByDefault = false, requiresDependencyResolution = ResolutionScope.COMPILE,
+      threadSafe = true, defaultPhase = LifecyclePhase.PACKAGE)
+public class AppZipMojo extends AbstractAppMojo {
+
+    public static final String ARTIFACT_TYPE_UUF_APP = "uuf-app";
+
+    @Override
+    protected String getOutputDirectoryPath() {
+        return pathOf(tempDirectoryPath, "app");
+    }
+
+    @Override
+    protected void validate() throws MojoExecutionException {
+        // Validation: Packaging type should be 'carbon-feature'
+        if (!ARTIFACT_TYPE_UUF_APP.equals(packaging)) {
+            throw new MojoExecutionException(
+                    "Packaging type of an UUF App should be '" + ARTIFACT_TYPE_UUF_APP + "'. Instead found '" +
+                            packaging + "'.");
+        }
+        super.validate();
+    }
+
+    @Override
+    protected void createProjectArtifact() throws MojoExecutionException {
+        File archive = ZipCreator.createArchive(Collections.singletonList(getOutputDirectoryPath()), null,
+                                                outputDirectoryPath, finalName);
+        project.getArtifact().setFile(archive);
+        projectHelper.attachArtifact(project, ZipCreator.ARCHIVE_FORMAT, null, archive);
+    }
+}

--- a/plugin/src/main/java/org/wso2/carbon/uuf/maven/ComponentMojo.java
+++ b/plugin/src/main/java/org/wso2/carbon/uuf/maven/ComponentMojo.java
@@ -46,8 +46,9 @@ import java.util.List;
       threadSafe = true, defaultPhase = LifecyclePhase.PACKAGE)
 public class ComponentMojo extends AbstractUUFMojo {
 
-    protected static final String FILE_COMPONENT_CONFIG = "component.yaml";
+    public static final String ARTIFACT_TYPE_UUF_COMPONENT = "uuf-component";
     public static final String FILE_BUNDLES = "bundles.yaml";
+    protected static final String FILE_COMPONENT_CONFIG = "component.yaml";
 
     /**
      * Path to the temporary directory for UUF Maven plugin.

--- a/plugin/src/main/java/org/wso2/carbon/uuf/maven/ThemeMojo.java
+++ b/plugin/src/main/java/org/wso2/carbon/uuf/maven/ThemeMojo.java
@@ -40,6 +40,7 @@ import java.util.Collections;
       threadSafe = true, defaultPhase = LifecyclePhase.PACKAGE)
 public class ThemeMojo extends AbstractUUFMojo {
 
+    public static final String ARTIFACT_TYPE_UUF_THEME = "uuf-theme";
     private static final String FILE_THEME = "theme.yaml";
 
     /**

--- a/plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/plugin/src/main/resources/META-INF/plexus/components.xml
@@ -108,5 +108,35 @@
                 </lifecycles>
             </configuration>
         </component>
+        <!--End copy-paste-->
+        <component>
+            <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+            <role-hint>uuf-app</role-hint>
+            <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler
+            </implementation>
+            <configuration>
+                <type>uuf-app</type>
+                <extension>zip</extension>
+                <packaging>uuf-app</packaging>
+                <classifier>uuf-app</classifier>
+                <language>html</language>
+            </configuration>
+        </component>
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>uuf-app</role-hint>
+            <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+            <configuration>
+                <lifecycles>
+                    <lifecycle>
+                        <id>default</id>
+                        <phases>
+                            <install>org.apache.maven.plugins:maven-install-plugin:install</install>
+                            <deploy>org.apache.maven.plugins:maven-deploy-plugin:deploy</deploy>
+                        </phases>
+                    </lifecycle>
+                </lifecycles>
+            </configuration>
+        </component>
     </components>
 </component-set>


### PR DESCRIPTION
This PR adds the **create-app-zip** goal to Carbon UUF Maven plugin. This goal bundles an UUF app to a normal zip archive (instead of a Carbon feature). When using `create-app-zip` goal, the packaging type should be `uuf-app`. Refer below sample `pom.xml`.
```xml
<project ...>
     <groupId>org.wso2.carbon.uuf.sample</groupId>
     <artifactId>org.wso2.carbon.uuf.sample.pets-store</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <packaging>uuf-app</packaging>
 ...
<build>
        <plugins>
            <plugin>
                <groupId>org.wso2.carbon.uuf.maven</groupId>
                <artifactId>carbon-uuf-maven-plugin</artifactId>
                <version>1.0.0-SNAPSHOT</version>
                <extensions>true</extensions>
                <executions>
                    <execution>
                        <id>create</id>
                        <phase>package</phase>
                        <goals>
                            <goal>create-app-zip</goal>
                        </goals>
                    </execution>
                </executions>
            </plugin>
        </plugins>
    </build>
</project>
```